### PR TITLE
Fix link to Eugene Weekly September article

### DIFF
--- a/src/markdown/about.mdx
+++ b/src/markdown/about.mdx
@@ -6,7 +6,7 @@ title: "about"
 
 In October 2014, a small team of unpaid volunteers brought 18 Oregon video games, 7 industry speakers, and one amazing art show to a co-working space in downtown Eugene. We called it Indie Game Con, advertised the best we could, opened the doors… and promptly filled to capacity. Over 400 people from around the state came to play games, meet developers, and learn about an industry that’s not only growing, but brought more than $100 million dollars into Oregon as recently as 2012.
 
-A decade prior, the previous Indie Game Con had catered to independent game developers, who came from around the world to learn from experts. Now, game development in Eugene is growing at an accelerated pace, and a global market has opened up to to independent developers, who sell their games online. To keep up with these changes, Indie Game Con has been reborn as a consumer-focused event that celebrates game culture, puts Oregon-made products in front of buyers, opens the door to aspirational and educational opportunities for our youth, and provides expert-level speaking sessions that are open to everyone.
+A decade prior, the previous Indie Game Con had catered to independent game developers, who came from around the world to learn from experts. Now, game development in Eugene is growing at an accelerated pace, and a global market has opened up to independent developers, who sell their games online. To keep up with these changes, Indie Game Con has been reborn as a consumer-focused event that celebrates game culture, puts Oregon-made products in front of buyers, opens the door to aspirational and educational opportunities for our youth, and provides expert-level speaking sessions that are open to everyone.
 
 We want to integrate local and state STEM organizations. We want to broadcast the event on the internet. We want to capture the attention of national media. We want to do this because we believe Indie Game Con can make a huge, positive impact on our local economy, and grow our state’s game development community.
 
@@ -19,4 +19,4 @@ The actual number is $111 million. Oregon is ninth in the nation for video game 
 The original Indie Games Con was a great idea, before its time. We count the founders of that event among our advisors and mentors.
 http://archive.gamedev.net/archive/columns/events/igc2004/index.html
 
-A September article in the Eugene Weekly gives an in-depth overview of Eugene’s game development history and present. http://www.eugeneweekly.com/20140925/lead-story/ahead-game
+A September article in the Eugene Weekly gives an in-depth overview of Eugene’s game development history and present. http://www.eugeneweekly.com/2014/09/25/ahead-of-the-game/


### PR DESCRIPTION
Link to September article in Eugene Weekly leads to a 404. This PR updates the link.

It also fixes a typo in the second paragraphy by removing a duplicate "to".
> a global market has opened up to ~to~ independent developers