### PR TITLE
Change links on homepage from /games to /developers

### DIFF
--- a/src/markdown/home.mdx
+++ b/src/markdown/home.mdx
@@ -11,11 +11,11 @@ It’s tricky to market a game without a budget. Laboring on your passion projec
 
 That’s why Indie Game Con (IGC) exists: to put creator-owned games in front of mainstream audiences, and build a space where game developers can hang out with their own. 
 
-2019 Marks the 6th annual IGC Eugene, OR..  This event is backed by Bitforest, a local non-profit organization sponsored by Innovate Oregon.  IGC is powered by volunteer tech and game dev professionals and its generous community sponsors.  It’s the ultimate expression of the inclusive game community in the Eugene area.
+2019 Marks the 6th annual IGC Eugene, OR.  This event is backed by Bitforest, a local non-profit organization sponsored by Innovate Oregon.  IGC is powered by volunteer tech and game dev professionals and its generous community sponsors.  It’s the ultimate expression of the inclusive game community in the Eugene area.
 
 This event features: Dozens of games developed by local creators, an Artist Alley, vendor booths, workshops, and panels. 
 
-### Signup as a [Contributor](/games/) or Buy a Ticket on [Eventbrite](https://indiegamecon2019.eventbrite.com)
+### Signup as a [Contributor](/developers) or Buy a Ticket on [Eventbrite](https://indiegamecon2019.eventbrite.com)
 
 ---
 
@@ -48,6 +48,6 @@ An indie game, or independent video game, is a video game that is often created 
 
 ## How do I contribute?
 
-#### Want to submit a game or check out submitted games? [Submit your game!](/games)
+#### Want to submit a game or check out [submitted games](/games)? [Submit your game!](/developers)
 
 #### View [Code of Conduct](/codeOfConduct)

--- a/src/markdown/home.mdx
+++ b/src/markdown/home.mdx
@@ -48,6 +48,6 @@ An indie game, or independent video game, is a video game that is often created 
 
 ## How do I contribute?
 
-#### Want to submit a game or check out [submitted games](/games)? [Submit your game!](/developers)
+#### [Submit your game](/developers) or check out [submitted games](/games)!
 
 #### View [Code of Conduct](/codeOfConduct)


### PR DESCRIPTION
Links on the homepage referencing the Submit a Game form point to `/games` instead of the new location at `/developers`.

This PR updates the links for Contributors and "Submit a Game!" to point to the new location of the form at `/developers`.

I also added a link to `/games` in line 51 since the text refers to submitted games. 

I'm happy to edit if needed.